### PR TITLE
update piet to v0.6

### DIFF
--- a/rough_piet/Cargo.toml
+++ b/rough_piet/Cargo.toml
@@ -17,10 +17,10 @@ readme = "README.md"
 roughr = {path = "../roughr", version = "0.3.0"}
 num-traits = "0.2"
 euclid = "0.22"
-piet = "0.5"
+piet = "0.6"
 palette = "0.6"
 
 [dev-dependencies]
-piet-common = {version = "0.5", features = ["png"]}
+piet-common = {version = "0.6", features = ["png"]}
 rand = "0.8"
 rand_distr = "0.4"


### PR DESCRIPTION
Simply a version bump, there were no API changes that affect rough_piet