### PR TITLE
feat: Add line cap and line join options

### DIFF
--- a/rough_piet/examples/stroke_style.rs
+++ b/rough_piet/examples/stroke_style.rs
@@ -1,0 +1,54 @@
+//! This example shows painting a rough rectangle using common-piet crate and
+//! kurbo rough shape generator
+
+use palette::Srgba;
+use piet::{Color, RenderContext};
+use piet_common::kurbo::Rect;
+use piet_common::Device;
+use rough_piet::KurboGenerator;
+use roughr::core::{LineCap, LineJoin, OptionsBuilder};
+
+const WIDTH: usize = 192;
+const HEIGHT: usize = 108;
+/// For now, assume pixel density (dots per inch)
+const DPI: f32 = 96.;
+
+/// Feature "png" needed for save_to_file() and it's disabled by default for optional dependencies
+/// cargo run --example mondrian --features png
+fn main() {
+    let mut device = Device::new().unwrap();
+    let mut bitmap = device.bitmap_target(WIDTH, HEIGHT, 1.0).unwrap();
+    let mut rc = bitmap.render_context();
+    let options = OptionsBuilder::default()
+        .stroke(Srgba::from_components((114u8, 87u8, 82u8, 255u8)).into_format())
+        .stroke_width(5.0)
+        .roughness(0.0)
+        .stroke_line_dash(vec![])
+        .line_cap(LineCap::Round)
+        .line_join(LineJoin::Round)
+        .build()
+        .unwrap();
+    let generator = KurboGenerator::new(options);
+    let rect_width = 100.0;
+    let rect_height = 50.0;
+    let rect = generator.rectangle::<f32>(
+        (WIDTH as f32 - rect_width) / 2.0,
+        (HEIGHT as f32 - rect_height) / 2.0,
+        rect_width,
+        rect_height,
+    );
+    let background_color = Color::from_hex_str("96C0B7").unwrap();
+
+    rc.fill(
+        Rect::new(0.0, 0.0, WIDTH as f64, HEIGHT as f64),
+        &background_color,
+    );
+    rect.draw(&mut rc);
+
+    rc.finish().unwrap();
+    std::mem::drop(rc);
+
+    bitmap
+        .save_to_file("stroke_style.png")
+        .expect("file save error");
+}

--- a/rough_piet/src/kurbo_generator.rs
+++ b/rough_piet/src/kurbo_generator.rs
@@ -7,7 +7,7 @@ use num_traits::{Float, FromPrimitive};
 use palette::rgb::Rgba;
 use palette::Srgba;
 use piet::kurbo::{BezPath, PathEl, Point};
-use piet::{Color, RenderContext, StrokeStyle};
+use piet::{Color, LineJoin, RenderContext, StrokeStyle};
 use roughr::core::{Drawable, OpSet, OpSetType, OpType, Options};
 use roughr::generator::Generator;
 
@@ -78,6 +78,12 @@ impl<F: Float + Trig> KurboDrawable<F> {
                         let mut ss = StrokeStyle::new();
                         ss.set_dash_pattern(stroke_line_dash.as_slice());
                         ss.set_dash_offset(self.options.stroke_line_dash_offset.unwrap_or(1.0f64));
+                        ss.set_line_cap(convert_line_cap_from_roughr_to_piet(
+                            self.options.line_cap,
+                        ));
+                        ss.set_line_join(convert_line_join_from_roughr_to_piet(
+                            self.options.line_join,
+                        ));
 
                         let stroke_color = self
                             .options
@@ -152,7 +158,12 @@ impl<F: Float + Trig> KurboDrawable<F> {
                         let mut ss = StrokeStyle::new();
                         ss.set_dash_pattern(fill_line_dash.as_slice());
                         ss.set_dash_offset(self.options.fill_line_dash_offset.unwrap_or(0.0f64));
-
+                        ss.set_line_cap(convert_line_cap_from_roughr_to_piet(
+                            self.options.line_cap,
+                        ));
+                        ss.set_line_join(convert_line_join_from_roughr_to_piet(
+                            self.options.line_join,
+                        ));
                         let fill_color = self
                             .options
                             .fill
@@ -328,5 +339,27 @@ impl KurboGenerator {
     ) -> KurboDrawable<F> {
         let drawable = self.gen.path(svg_path, &self.options);
         drawable.to_kurbo_drawable()
+    }
+}
+
+fn convert_line_cap_from_roughr_to_piet(
+    roughr_line_cap: Option<roughr::core::LineCap>,
+) -> piet::LineCap {
+    match roughr_line_cap {
+        Some(roughr::core::LineCap::Butt) => piet::LineCap::Butt,
+        Some(roughr::core::LineCap::Round) => piet::LineCap::Round,
+        Some(roughr::core::LineCap::Square) => piet::LineCap::Square,
+        None => piet::LineCap::Butt,
+    }
+}
+
+fn convert_line_join_from_roughr_to_piet(
+    roughr_line_join: Option<roughr::core::LineJoin>,
+) -> LineJoin {
+    match roughr_line_join {
+        Some(roughr::core::LineJoin::Miter { limit }) => LineJoin::Miter { limit },
+        Some(roughr::core::LineJoin::Round) => LineJoin::Round,
+        Some(roughr::core::LineJoin::Bevel) => LineJoin::Bevel,
+        None => LineJoin::Miter { limit: LineJoin::DEFAULT_MITER_LIMIT },
     }
 }

--- a/rough_tiny_skia/src/skia_generator.rs
+++ b/rough_tiny_skia/src/skia_generator.rs
@@ -10,6 +10,7 @@ use roughr::generator::Generator;
 use tiny_skia::{
     FillRule,
     LineCap,
+    LineJoin,
     Paint,
     Path,
     PathBuilder,
@@ -82,7 +83,10 @@ impl<F: Float + Trig> SkiaDrawable<F> {
                     if self.options.stroke_line_dash.is_some() {
                         let mut stroke = Stroke {
                             width: self.options.stroke_width.unwrap_or(1.0),
-                            line_cap: LineCap::Round,
+                            line_cap: convert_line_cap_from_roughr_to_piet(self.options.line_cap),
+                            line_join: convert_line_join_from_roughr_to_piet(
+                                self.options.line_join,
+                            ),
                             ..Stroke::default()
                         };
                         let stroke_line_dash = self
@@ -185,7 +189,10 @@ impl<F: Float + Trig> SkiaDrawable<F> {
                     if self.options.fill_line_dash.is_some() {
                         let mut stroke = Stroke::default();
                         stroke.width = self.options.fill_weight.unwrap_or(1.0);
-                        stroke.line_cap = LineCap::Round;
+                        stroke.line_cap =
+                            convert_line_cap_from_roughr_to_piet(self.options.line_cap);
+                        stroke.line_join =
+                            convert_line_join_from_roughr_to_piet(self.options.line_join);
                         let fill_line_dash = self
                             .options
                             .fill_line_dash
@@ -219,7 +226,10 @@ impl<F: Float + Trig> SkiaDrawable<F> {
                     } else {
                         let mut stroke = Stroke::default();
                         stroke.width = self.options.fill_weight.unwrap_or(1.0);
-                        stroke.line_cap = LineCap::Round;
+                        stroke.line_cap =
+                            convert_line_cap_from_roughr_to_piet(self.options.line_cap);
+                        stroke.line_join =
+                            convert_line_join_from_roughr_to_piet(self.options.line_join);
 
                         let fill_color = self
                             .options
@@ -383,5 +393,25 @@ impl SkiaGenerator {
     ) -> SkiaDrawable<F> {
         let drawable = self.gen.path(svg_path, &self.options);
         drawable.to_skia_drawable()
+    }
+}
+
+fn convert_line_cap_from_roughr_to_piet(roughr_line_cap: Option<roughr::core::LineCap>) -> LineCap {
+    match roughr_line_cap {
+        Some(roughr::core::LineCap::Butt) => LineCap::Butt,
+        Some(roughr::core::LineCap::Round) => LineCap::Round,
+        Some(roughr::core::LineCap::Square) => LineCap::Square,
+        None => LineCap::Round,
+    }
+}
+
+fn convert_line_join_from_roughr_to_piet(
+    roughr_line_join: Option<roughr::core::LineJoin>,
+) -> LineJoin {
+    match roughr_line_join {
+        Some(roughr::core::LineJoin::Miter { limit: _ }) => LineJoin::Miter,
+        Some(roughr::core::LineJoin::Round) => LineJoin::Round,
+        Some(roughr::core::LineJoin::Bevel) => LineJoin::Bevel,
+        None => LineJoin::Miter,
     }
 }

--- a/roughr/src/core.rs
+++ b/roughr/src/core.rs
@@ -27,6 +27,35 @@ pub enum FillStyle {
     ZigZagLine,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LineCap {
+    Butt,
+    Round,
+    Square,
+}
+
+impl Default for LineCap {
+    fn default() -> Self {
+        LineCap::Butt
+    }
+}
+
+/// Options for angled joins in strokes.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum LineJoin {
+    Miter { limit: f64 },
+    Round,
+    Bevel,
+}
+impl LineJoin {
+    pub const DEFAULT_MITER_LIMIT: f64 = 10.0;
+}
+impl Default for LineJoin {
+    fn default() -> Self {
+        LineJoin::Miter { limit: LineJoin::DEFAULT_MITER_LIMIT }
+    }
+}
+
 #[derive(Clone, Builder)]
 #[builder(setter(strip_option))]
 pub struct Options {
@@ -71,6 +100,10 @@ pub struct Options {
     #[builder(default = "None")]
     pub stroke_line_dash_offset: Option<f64>,
     #[builder(default = "None")]
+    pub line_cap: Option<LineCap>,
+    #[builder(default = "None")]
+    pub line_join: Option<LineJoin>,
+    #[builder(default = "None")]
     pub fill_line_dash: Option<Vec<f64>>,
     #[builder(default = "None")]
     pub fill_line_dash_offset: Option<f64>,
@@ -112,6 +145,8 @@ impl Default for Options {
             simplification: Some(1.0),
             stroke_line_dash: None,
             stroke_line_dash_offset: None,
+            line_cap: None,
+            line_join: None,
             fill_line_dash: None,
             fill_line_dash_offset: None,
             fixed_decimal_place_digits: None,


### PR DESCRIPTION
Add line cap and line join options #13
in rough_piet/examples/stroke_style.rs,
without line_cap and line_join round:
![stroke_style.png](https://vip2.loli.io/2023/08/27/FvsXlVLM6OjrcAd.png)
with line_cap and line_join round:
![stroke_style.png](https://vip2.loli.io/2023/08/27/XS86A57Hg3uqthE.png)