### PR TITLE
Bump all dependencies

### DIFF
--- a/points_on_curve/Cargo.toml
+++ b/points_on_curve/Cargo.toml
@@ -18,5 +18,5 @@ euclid = "0.22"
 num-traits = "0.2"
 
 [dev-dependencies]
-piet-common = {version = "0.5", features = ["png"]}
-piet = "0.5"
+piet-common = {version = "0.6", features = ["png"]}
+piet = "0.6"

--- a/rough_tiny_skia/Cargo.toml
+++ b/rough_tiny_skia/Cargo.toml
@@ -16,4 +16,4 @@ roughr = {path = "../roughr", version = "0.6.0"}
 num-traits = "0.2"
 euclid = "0.22"
 palette = "0.7"
-tiny-skia = "0.8"
+tiny-skia = "0.11"

--- a/roughr/Cargo.toml
+++ b/roughr/Cargo.toml
@@ -19,8 +19,8 @@ svg_path_ops = {path= "../svg_path_ops", version = "0.5.0"}
 euclid = "0.22"
 rand = "0.8"
 num-traits = "0.2"
-derive_builder = "0.11"
-svgtypes = "0.8"
+derive_builder = "0.12"
+svgtypes = "0.11"
 palette = "0.7"
 
 [dev-dependencies]

--- a/svg_path_ops/Cargo.toml
+++ b/svg_path_ops/Cargo.toml
@@ -14,4 +14,4 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-svgtypes = "0.8"
+svgtypes = "0.11"


### PR DESCRIPTION
None of these required any code change.  These also clean up the dependency tree, going from 223 crates built down to 188.