### PR TITLE
update piet dependency in rough_piet

### DIFF
--- a/rough_piet/Cargo.toml
+++ b/rough_piet/Cargo.toml
@@ -17,11 +17,11 @@ readme = "README.md"
 roughr = { path = "../roughr", version = "0.12.0" }
 num-traits = "0.2"
 euclid = "0.22"
-piet = "0.7"
+piet = "0.8"
 palette = "0.7"
 
 [dev-dependencies]
-piet-common = { version = "0.7", features = ["png"] }
+piet-common = { version = "0.8", features = ["png"] }
 rand = "0.8"
 rand_distr = "0.4"
 svg_path_ops = { path = "../svg_path_ops", version = "0.11.0" }


### PR DESCRIPTION
piet itself only had dependency updates (cairo), so only a version bump is necessary.